### PR TITLE
API Key validation.

### DIFF
--- a/src/ApiRest.php
+++ b/src/ApiRest.php
@@ -19,8 +19,11 @@ final class ApiRest implements IApi
 
 	public function __construct(string $apiKey)
 	{
-		if (trim($apiKey) === '') {
-			throw new \RuntimeException('API key can not be empty.');
+		if (($apiKey = trim($apiKey)) === '') {
+			throw new \InvalidArgumentException('API key can not be empty.');
+		}
+		if (strlen($apiKey) < 5) {
+			throw new \InvalidArgumentException('API key "' . $apiKey . '" is too short.');
 		}
 		$this->apiKey = $apiKey;
 	}

--- a/src/ApiSoap.php
+++ b/src/ApiSoap.php
@@ -18,8 +18,11 @@ final class ApiSoap implements IApi
 
 	public function __construct(string $apiKey)
 	{
-		if (trim($apiKey) === '') {
-			throw new \RuntimeException('API key can not be empty.');
+		if (($apiKey = trim($apiKey)) === '') {
+			throw new \InvalidArgumentException('API key can not be empty.');
+		}
+		if (strlen($apiKey) < 5) {
+			throw new \InvalidArgumentException('API key "' . $apiKey . '" is too short.');
 		}
 		$this->apiKey = $apiKey;
 		try {


### PR DESCRIPTION
Invalid API key should be reported as InvalidArgumentException + minimal length is 5 characters (by doc.).