### PR TITLE
ApiRest: Show details only if it is available.

### DIFF
--- a/src/ApiRest.php
+++ b/src/ApiRest.php
@@ -220,7 +220,7 @@ final class ApiRest implements IApi
 
 
 	/**
-	 * @param mixed [] $result
+	 * @param mixed[] $result
 	 * @throws RestFault|PacketAttributesFault
 	 */
 	private function processResult(array $result): void
@@ -229,7 +229,10 @@ final class ApiRest implements IApi
 			if ($result['fault'] === 'PacketAttributesFault') {
 				throw new PacketAttributesFault($result['detail']['attributes']['fault'] ?? 'Unknown error.');
 			}
-			throw new RestFault($result['fault'] . ': ' . ($result['string'] ?? 'Unknown error') . json_encode($result['detail'] ?? ''));
+			throw new RestFault(
+				$result['fault'] . ': ' . ($result['string'] ?? 'Unknown error')
+				. (isset($result['detail']) && $result['detail'] ? "\n" . 'Details: ' . json_encode($result['detail']) : '')
+			);
 		}
 	}
 }


### PR DESCRIPTION
Remake old exception message with empty array:

![Snímek obrazovky 2021-01-04 v 16 35 37](https://user-images.githubusercontent.com/4738758/103551997-7ee14a00-4eab-11eb-8412-09aedf43fb75.png)

To message without array (if is empty):

![Snímek obrazovky 2021-01-04 v 16 38 31](https://user-images.githubusercontent.com/4738758/103552007-8274d100-4eab-11eb-88ee-47bed985e812.png)
