### PR TITLE
PacketAttributesFault: Input can be object or array.

### DIFF
--- a/src/Exception/PacketAttributesFault.php
+++ b/src/Exception/PacketAttributesFault.php
@@ -16,6 +16,10 @@ final class PacketAttributesFault extends \Exception
 	 */
 	public function __construct($fails)
 	{
+		$fails = (array) $fails;
+		if (\count($fails) > 0 && isset($fails[0]) === false) {
+			$fails = [$fails];
+		}
 		foreach (((array) $fails) as $fail) {
 			$fail = (array) $fail;
 			$this->fails[$fail['name'] ?? '???'] = (string) ($fail['fault'] ?? '???');

--- a/src/Exception/PacketAttributesFault.php
+++ b/src/Exception/PacketAttributesFault.php
@@ -17,7 +17,8 @@ final class PacketAttributesFault extends \Exception
 	public function __construct($fails)
 	{
 		foreach (((array) $fails) as $fail) {
-			$this->fails[$fail->name] = (string) $fail->fault;
+			$fail = (array) $fail;
+			$this->fails[$fail['name'] ?? '???'] = (string) ($fail['fault'] ?? '???');
 		}
 		parent::__construct((string) $this);
 	}
@@ -27,7 +28,7 @@ final class PacketAttributesFault extends \Exception
 	{
 		$return = '';
 		foreach ($this->fails as $name => $fail) {
-			$return .= $name . ': ' . $fail . ', ';
+			$return .= $name . ': ' . $fail . "\n";
 		}
 
 		return trim($return, ', ');


### PR DESCRIPTION
Input of `PacketAttributesFault` can be object or array. Now is normalized to array for correct rendering.

Before:

<img width="1425" alt="Snímek obrazovky 2021-01-11 v 11 18 40" src="https://user-images.githubusercontent.com/4738758/104168895-06c0da00-53ff-11eb-9474-096b51757eac.png">
