### PR TITLE
Change carrierPickupPoint to string

### DIFF
--- a/src/Model/PacketAttributes.php
+++ b/src/Model/PacketAttributes.php
@@ -44,7 +44,7 @@ final class PacketAttributes implements IModel
 
     private ?string $zip;
 
-    private ?int $carrierPickupPoint;
+    private ?string $carrierPickupPoint;
 
     private ?string $carrierService;
 
@@ -72,7 +72,7 @@ final class PacketAttributes implements IModel
         ?string $houseNumber = null,
         ?string $city = null,
         ?string $zip = null,
-        ?int $carrierPickupPoint = null,
+        ?string $carrierPickupPoint = null,
         ?string $carrierService = null,
         ?DispatchOrder $dispatchOrder = null,
         ?string $customerBarcode = null
@@ -325,13 +325,13 @@ final class PacketAttributes implements IModel
     }
 
 
-    public function getCarrierPickupPoint(): ?int
+    public function getCarrierPickupPoint(): ?string
     {
         return $this->carrierPickupPoint;
     }
 
 
-    public function setCarrierPickupPoint(?int $carrierPickupPoint): void
+    public function setCarrierPickupPoint(?string $carrierPickupPoint): void
     {
         $this->carrierPickupPoint = $carrierPickupPoint;
     }


### PR DESCRIPTION
https://docs.packetery.com/03-creating-packets/06-packetery-api-reference.html#toc-packetattributes

Type: string
FIeld name: carrierPickupPoint
Constraints: 1-32 alphanumeric
Required: yes for some carriers
Description: Code of a carrier's pick up point. Required only if the chosen carrier offers them.

Example:
carrierId: 3060
carrierPickupPoint: RUM02N
